### PR TITLE
Lightbox opens the wrong image if there is a pagination and the order…

### DIFF
--- a/src/components/data-context/DataContext.tsx
+++ b/src/components/data-context/DataContext.tsx
@@ -129,7 +129,10 @@ const DataProvider: React.FC<React.PropsWithChildren> = ({children}) => {
     if (fetchUrl) {
       const queryStringSeperator: string = fetchUrl.includes('?') ? '&' : '?';
       let queryString = queryStringSeperator;
-      queryString += `timestamp=${getGalleryTimestamp?.()}`;
+
+      queryString += `order_by=${orderBy}`;
+      queryString += `&order=${orderDirection}`;
+      queryString += `&timestamp=${getGalleryTimestamp?.()}`;
       const imgData: any[] = (await axios.get(`${fetchUrl}${queryString}`))
         .data;
       const newImages: IImageDTO[] = imgData.map((data: any) => ({


### PR DESCRIPTION
Lightbox opens the wrong image if there is a pagination and the ordering is not default.

To fix add get parameters order, order_by to the request of getting whole images for lightbox.